### PR TITLE
Support Android debuggable apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ The plugin will create 3 tasks :
 - appCenterUploadBetaRelease
 - appCenterUploadProdRelease
 
-> Note: Application signed with Android debug certificate can't be installed from AppCenter, so the plugin ignore debug profiles
 
 ## Override properties
 

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/AppCenterPlugin.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/AppCenterPlugin.kt
@@ -33,9 +33,6 @@ class AppCenterPlugin : Plugin<Project> {
     }
 
     private fun handleVariant(variant: ApplicationVariant, appCenterExtension: AppCenterExtension, project: Project) {
-        if (variant.signingConfig?.keyAlias == "AndroidDebugKey") {
-            return
-        }
 
         val appCenterApp = variant.productFlavors.map {
             appCenterExtension.findByFlavor(


### PR DESCRIPTION
Support debuggable APKs, as Hockeyapp and AppCenter are able to install them.

We use Hockeyapp to distribute debuggable APKs to our Android engineering team, and it does seem to work on AppCenter too. Would you consider this PR?