### PR TITLE
Fixed usage of deprecated ApkVariant methods in AGP 3.3+

### DIFF
--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/tasks/UploadAppCenterTask.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/tasks/UploadAppCenterTask.kt
@@ -14,7 +14,7 @@ open class UploadAppCenterTask : DefaultTask() {
     lateinit var appName: String
     var distributionGroups: List<String> = emptyList()
 
-    lateinit var file: File
+    lateinit var fileProvider: () -> File
     var releaseNotes: Any? = null
 
     private var logger = services[ProgressLoggerFactory::class.java]
@@ -24,7 +24,7 @@ open class UploadAppCenterTask : DefaultTask() {
     fun upload() {
         logger.start("AppCenter Upload", "Step 0/4")
         val uploader = AppCenterUploaderFactory().create(apiToken, ownerName, appName)
-        uploader.upload(file, toReleaseNotes(releaseNotes), distributionGroups) {
+        uploader.upload(fileProvider(), toReleaseNotes(releaseNotes), distributionGroups) {
             logger.progress(it)
         }
         logger.completed("AppCenter Upload completed", false)


### PR DESCRIPTION
As of plugin version 1.1.2, the following warning occurs:
```
WARNING: API 'variantOutput.getPackageApplication()' is obsolete and has been
replaced with 'variant.getPackageApplicationProvider()'.
```
It is triggered by this call:
```kotlin
t.file = output.outputFile
```

This PR fixes the issue by using Task Configuration Avoidance API.