### PR TITLE
Set a higher write-timeout for larger files.

### DIFF
--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/OkHttpFactory.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/OkHttpFactory.kt
@@ -10,6 +10,7 @@ class OkHttpFactory {
         val builder = OkHttpClient().newBuilder()
         builder.readTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         builder.connectTimeout(DEFAULT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        builder.writeTimeout(WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
 
         if (debug) {
             val interceptor = HttpLoggingInterceptor()
@@ -23,5 +24,6 @@ class OkHttpFactory {
     companion object {
 
         const val DEFAULT_TIMEOUT_SECONDS: Long = 20
+        const val WRITE_TIMEOUT_SECONDS: Long = 5 * 60
     }
 }


### PR DESCRIPTION
I already increased the timeouts for read and connect in a previous pr. But I recognized that I changed the wrong timeouts and a upload of big files could still cause a SocketTimeOutException if the bandwidth is limited. E.g. if you have a bandwidth of 1mb/s you wouldn't be able to write files larger than 10MB (the default timeout for writing is 10 seconds). I read that app center has a limit of 4GB for app files. So maybe you should consider to add a parameter to the extension to control the timeouts and support really big files.