### PR TITLE
com.android.tools.build:gradle minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ appcenter {
 }
 ```
 
+## Prerequisite
+- com.android.tools.build:gradle >= 3.3.0
+
 ## Use Environment Variables (for CI use)
 - `APPCENTER_API_TOKEN` : AppCenter API token
 - `APPCENTER_OWNER_NAME` : Owner name


### PR DESCRIPTION
In order to get the plugin working, com.android.tools.build:gradle must be 3.3.0 or newer.
else the error: NotSuchMethod com.android.build.gradle.api.ApplicationVariant.getPackageApplicationProvider()
Maybe this can be checked when running the plugin to show a meaningful error to the user.