### PR TITLE
Added filter identifiers to task name to avoid the same names error

### DIFF
--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/AppCenterPlugin.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/AppCenterPlugin.kt
@@ -51,8 +51,11 @@ class AppCenterPlugin : Plugin<Project> {
 
             variant.outputs.all { output ->
                 if (output is ApkVariantOutput) {
+                    val filterIdentifiersCapitalized = output.filters
+                            .joinToString("") { filter -> filter.identifier.capitalize() }
                     project.tasks.register(
-                        "appCenterUpload${variant.name.capitalize()}", UploadAppCenterTask::class.java
+                            "appCenterUpload${variant.name.capitalize()}$filterIdentifiersCapitalized",
+                            UploadAppCenterTask::class.java
                     ) { uploadTask ->
                         uploadTask.group = APP_CENTER_PLUGIN_GROUP
                         uploadTask.description = "Upload apk to AppCenter"


### PR DESCRIPTION
https://github.com/oliviergauthier/gradle-appcenter-plugin/issues/28
If there are multiple output files with different filters, we should add these filters identifiers to the task name to avoid the same names
![image](https://user-images.githubusercontent.com/5062363/67896016-94066e80-fb6c-11e9-9112-b762edfa3bd9.png)
