### PR TITLE
Add a flag to disable uploading of mapping files

### DIFF
--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/AppCenterPlugin.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/AppCenterPlugin.kt
@@ -47,7 +47,6 @@ class AppCenterPlugin : Plugin<Project> {
 
             val outputDirectory = variant.packageApplicationProvider.get().outputDirectory
             val assembleTask = variant.assembleProvider.get()
-            val mappingFile = variant.mappingFile
 
             variant.outputs.all { output ->
                 if (output is ApkVariantOutput) {
@@ -65,7 +64,12 @@ class AppCenterPlugin : Plugin<Project> {
                         uploadTask.releaseNotes = appCenterApp.releaseNotes
                         uploadTask.notifyTesters = appCenterApp.notifyTesters
 
-                        uploadTask.mappingFileProvider = { mappingFile }
+                        if (appCenterApp.uploadMappingFiles) {
+                            val mappingFile = variant.mappingFile
+                            uploadTask.mappingFileProvider = { mappingFile }
+                        } else {
+                            uploadTask.mappingFileProvider = { null }
+                        }
                         uploadTask.versionName = variant.versionName
                         uploadTask.versionCode = variant.versionCode
                         uploadTask.symbols = appCenterApp.symbols

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/extensions/AppCenterAppExtension.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/extensions/AppCenterAppExtension.kt
@@ -6,7 +6,8 @@ open class AppCenterAppExtension(val name: String, val parent: AppCenterExtensio
     private var _ownerName: String? = null
     private var _distributionGroups: List<String>? = null
     private var _releaseNotes: Any? = null
-    private var _notifyTester: Boolean? = null
+    private var _notifyTesters: Boolean? = null
+    private var _uploadMappingFiles: Boolean? = null
     private var _symbols: List<Any>? = null
 
     var dimension: String? = null
@@ -50,10 +51,18 @@ open class AppCenterAppExtension(val name: String, val parent: AppCenterExtensio
 
     var notifyTesters: Boolean
         get() {
-            return _notifyTester ?: parent.notifyTesters
+            return _notifyTesters ?: parent.notifyTesters
         }
         set(value) {
-            _notifyTester = value
+            _notifyTesters = value
+        }
+
+    var uploadMappingFiles: Boolean
+        get() {
+            return _uploadMappingFiles ?: parent.uploadMappingFiles
+        }
+        set(value) {
+            _uploadMappingFiles = value
         }
 
     var symbols: List<Any>

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/extensions/AppCenterExtension.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/extensions/AppCenterExtension.kt
@@ -73,6 +73,8 @@ open class AppCenterExtension(val project: Project) {
             _symbols = value
         }
 
+    var uploadMappingFiles: Boolean = true
+
     fun apps(action: Action<NamedDomainObjectContainer<AppCenterAppExtension>>) {
         action.execute(apps)
     }


### PR DESCRIPTION
We use DexGuard which generates mapping files in a non-standard location and when we use this plugin it fails to upload mapping files because it cannot find them.
So I added a flag to disable uploading of mapping files. It might also be useful to those who don't use crash reports feature on App Center as mapping files could get quite big (60MiB+ for our app).