### PR TITLE
Add support for the Android Gradle Plugin 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.1.16"
+        classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.1.18"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.3.50'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
 }
 
 apply plugin: "com.gradle.plugin-publish"
@@ -34,7 +34,7 @@ dependencies {
     compileOnly gradleApi()
 
     // Third Party
-    compileOnly 'com.android.tools.build:gradle:3.5.0'
+    compileOnly 'com.android.tools.build:gradle:3.6.0-rc01'
 
     compile 'com.squareup.okhttp3:okhttp:3.12.1'
     compile 'com.squareup.okhttp3:logging-interceptor:3.4.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/integration-test/resources/MyApplication/build.gradle
+++ b/src/integration-test/resources/MyApplication/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.11'
+    ext.kotlin_version = '1.3.61'
     repositories {
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -11,7 +11,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.6.0-rc01'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.1.12-SNAPSHOT"
         // NOTE: Do not place your application dependencies here; they belong

--- a/src/integration-test/resources/MyApplication/gradle/wrapper/gradle-wrapper.properties
+++ b/src/integration-test/resources/MyApplication/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jan 17 21:08:44 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/AppCenterPlugin.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/AppCenterPlugin.kt
@@ -45,7 +45,7 @@ class AppCenterPlugin : Plugin<Project> {
 
         appCenterApp?.let {
 
-            val outputDirectory = variant.packageApplicationProvider.get().outputDirectory
+            val outputDirectory = variant.packageApplicationProvider.get().outputDirectory.get().asFile
             val assembleTask = variant.assembleProvider.get()
 
             variant.outputs.all { output ->
@@ -55,8 +55,8 @@ class AppCenterPlugin : Plugin<Project> {
                     val taskSuffix = "${variant.name.capitalize()}$filterIdentifiersCapitalized"
 
                     val uploadTask = project.tasks.register(
-                            "appCenterUpload$taskSuffix",
-                            UploadAppCenterTask::class.java
+                        "appCenterUpload$taskSuffix",
+                        UploadAppCenterTask::class.java
                     ) { uploadTask ->
 
                         uploadTask.group = APP_CENTER_PLUGIN_GROUP
@@ -71,7 +71,7 @@ class AppCenterPlugin : Plugin<Project> {
                         uploadTask.notifyTesters = appCenterApp.notifyTesters
 
                         if (appCenterApp.uploadMappingFiles) {
-                            uploadTask.mappingFileProvider = { variant.mappingFile }
+                            uploadTask.mappingFileProvider = { variant.mappingFileProvider.get().singleFile }
                         } else {
                             uploadTask.mappingFileProvider = { null }
                         }

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
@@ -70,7 +70,7 @@ class AppCenterUploader(
         }
     }
 
-    fun uploadSymbols(mappingFile: File, versionName: String, versionCode : String, logger: (String) -> Unit) {
+    fun uploadSymbols(mappingFile: File, versionName: String, versionCode: String, logger: (String) -> Unit) {
         logger("Step 1/3 : Prepare Symbol")
         val prepareRequest = PrepareSymbolUploadRequest(
             symbolType = "AndroidProguard",
@@ -89,7 +89,7 @@ class AppCenterUploader(
         val preparedUpload = prepareResponse.body()!!
 
         logger("Step 2/3 : Upload Symbol")
-        val uploadResponse = doUploadSymbol(preparedUpload.uploadUrl, mappingFile, logger).execute()
+        val uploadResponse = doUploadSymbol(preparedUpload.uploadUrl, mappingFile).execute()
         if (!uploadResponse.isSuccessful) {
             throw AppCenterUploaderException(
                 "Can't upload mapping, code=${uploadResponse.code()}, " +
@@ -114,7 +114,7 @@ class AppCenterUploader(
             .addFormDataPart(
                 "ipa", file.name,
                 ProgressRequestBody(file, "application/octet-stream") { current, total ->
-                    val progress : Int = ((current.toDouble() / total) * 100).toInt()
+                    val progress: Int = ((current.toDouble() / total) * 100).toInt()
                     logger("Step 2/4 : Upload apk ($progress %)")
                 }
             )
@@ -128,7 +128,7 @@ class AppCenterUploader(
         return okHttpClient.newCall(request)
     }
 
-    private fun doUploadSymbol(uploadUrl: String, file: File, logger: (String) -> Unit): Call {
+    private fun doUploadSymbol(uploadUrl: String, file: File): Call {
         val request = Request.Builder()
             .url(uploadUrl)
             .addHeader("x-ms-blob-type", "BlockBlob")
@@ -137,9 +137,6 @@ class AppCenterUploader(
 
         return okHttpClient.newCall(request)
     }
-
-
-
 }
 
 class AppCenterUploaderException(message: String) : Exception(message)


### PR DESCRIPTION
Fixes #41

When this is released the README needs to be updated:
- The latest plugin version (1.1.18) needs to change to the new version number
- Android Gradle Plugin 3.3 compatibility needs to change to 3.6

But I think it is a better idea to create a compatibility list that tells users which version of the plugin is compatible with which version of the Android Gradle Plugin. Because you cannot posibly support multiple Android Gradle Plugin versions in one version of your plugin.

For an example check my plugin's readme: https://github.com/NeoTech-Software/Android-Root-Coverage-Plugin

Thanks for your work on this plugin!