### PR TITLE
Upgrade OkHttp and Retrofit versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,10 @@ dependencies {
     // Third Party
     compileOnly 'com.android.tools.build:gradle:3.6.0-rc01'
 
-    compile 'com.squareup.okhttp3:okhttp:3.12.1'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.4.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.6.1'
-    compile 'com.squareup.retrofit2:retrofit:2.6.1'
+    compile 'com.squareup.okhttp3:okhttp:4.7.2'
+    compile 'com.squareup.okhttp3:logging-interceptor:4.7.2'
+    compile 'com.squareup.retrofit2:converter-gson:2.9.0'
+    compile 'com.squareup.retrofit2:retrofit:2.9.0'
 
     // Testing
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterAPIFactory.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterAPIFactory.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Project
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-class AppCenterAPIFactory(
+internal class AppCenterAPIFactory(
     private val project: Project
 ) {
 

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
@@ -1,6 +1,8 @@
 package com.betomorrow.gradle.appcenter.infra
 
 import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
 
 private const val RELEASE_URL_TEMPLATE = "https://appcenter.ms/orgs/%s/apps/%s/distribute/releases/%s"
@@ -32,8 +34,8 @@ class AppCenterUploader(
         val uploadResponse = doUploadApk(preparedUpload.uploadUrl, file, logger).execute()
         if (!uploadResponse.isSuccessful) {
             throw AppCenterUploaderException(
-                "Can't upload APK, code=${uploadResponse.code()}, " +
-                        "reason=${uploadResponse.body()?.string()}"
+                "Can't upload APK, code=${uploadResponse.code}, " +
+                        "reason=${uploadResponse.body?.string()}"
             )
         }
 
@@ -92,8 +94,8 @@ class AppCenterUploader(
         val uploadResponse = doUploadSymbol(preparedUpload.uploadUrl, mappingFile).execute()
         if (!uploadResponse.isSuccessful) {
             throw AppCenterUploaderException(
-                "Can't upload mapping, code=${uploadResponse.code()}, " +
-                        "reason=${uploadResponse.body()?.string()}"
+                "Can't upload mapping, code=${uploadResponse.code}, " +
+                        "reason=${uploadResponse.body?.string()}"
             )
         }
 
@@ -132,7 +134,7 @@ class AppCenterUploader(
         val request = Request.Builder()
             .url(uploadUrl)
             .addHeader("x-ms-blob-type", "BlockBlob")
-            .put(RequestBody.create(MediaType.parse("text/plain; charset=UTF-8"), file))
+            .put(file.asRequestBody("text/plain; charset=UTF-8".toMediaTypeOrNull()))
             .build()
 
         return okHttpClient.newCall(request)

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploaderFactory.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploaderFactory.kt
@@ -2,7 +2,7 @@ package com.betomorrow.gradle.appcenter.infra
 
 import org.gradle.api.Project
 
-class AppCenterUploaderFactory(
+internal class AppCenterUploaderFactory(
     private val project: Project
 ) {
 

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/OkHttpBuilder.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/OkHttpBuilder.kt
@@ -7,7 +7,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import org.gradle.api.Project
 import java.util.concurrent.TimeUnit
 
-class OkHttpBuilder(
+internal class OkHttpBuilder(
     private val project: Project
 ) {
 

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/ProgressRequestBody.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/ProgressRequestBody.kt
@@ -33,14 +33,11 @@ internal class ProgressRequestBody(
         var source: Source? = null
         try {
             source = file.source()
-            if (source == null) {
-                return
-            }
 
             var total: Long = 0
             var read: Long = 0
 
-            while ({read = source.read(sink.buffer(),
+            while ({read = source.read(sink.buffer,
                     SEGMENT_SIZE
                 ); read}() != -1L) {
                 total += read

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/ProgressRequestBody.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/ProgressRequestBody.kt
@@ -1,16 +1,16 @@
 package com.betomorrow.gradle.appcenter.infra
 
 import okhttp3.MediaType
-import okio.Okio
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import java.io.IOException
 import okio.BufferedSink
 import okhttp3.RequestBody
-import okhttp3.internal.Util
+import okhttp3.internal.closeQuietly
 import okio.Source
+import okio.source
 import java.io.File
 
-
-class ProgressRequestBody(
+internal class ProgressRequestBody(
     private val file: File,
     private val contentType: String,
     private val listener: (Long, Long) -> Unit
@@ -25,14 +25,14 @@ class ProgressRequestBody(
     }
 
     override fun contentType(): MediaType? {
-        return MediaType.parse(contentType)
+        return contentType.toMediaTypeOrNull()
     }
 
     @Throws(IOException::class)
     override fun writeTo(sink: BufferedSink) {
         var source: Source? = null
         try {
-            source = Okio.source(file)
+            source = file.source()
             if (source == null) {
                 return
             }
@@ -48,7 +48,7 @@ class ProgressRequestBody(
                 this.listener(total, contentLength)
             }
         } finally {
-            Util.closeQuietly(source)
+            source?.closeQuietly()
         }
     }
 

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/utils/StringExtensions.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/utils/StringExtensions.kt
@@ -2,6 +2,6 @@ package com.betomorrow.gradle.appcenter.utils
 
 import kotlin.math.min
 
-fun String.truncate(maxLength: Int) : String {
+internal fun String.truncate(maxLength: Int) : String {
     return this.substring(0, min(this.length, maxLength))
 }


### PR DESCRIPTION
Upgrades OkHttp to version 4.7.2 and Retrofit to 2.9.0

Resolves issues caused in CI due to conflicting OkHttp versions.

```
* What went wrong:
Execution failed for task ':modules:testapp:MyTestApp:appCenterUploadDebug'.
> okhttp3.internal.platform.Platform.log(ILjava/lang/String;Ljava/lang/Throwable;)V
```