### PR TITLE
Adding breakpad type for symbols upload

### DIFF
--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
@@ -70,10 +70,10 @@ class AppCenterUploader(
         }
     }
 
-    fun uploadSymbols(mappingFile: File, versionName: String, versionCode: String, logger: (String) -> Unit) {
+    fun uploadSymbols(mappingFile: File, symbolType:String, versionName: String, versionCode: String, logger: (String) -> Unit) {
         logger("Step 1/3 : Prepare Symbol")
         val prepareRequest = PrepareSymbolUploadRequest(
-            symbolType = "AndroidProguard",
+            symbolType = symbolType,
             fileName = mappingFile.name,
             version = versionName,
             build = versionCode

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/tasks/UploadAppCenterTask.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/tasks/UploadAppCenterTask.kt
@@ -41,7 +41,7 @@ open class UploadAppCenterTask : DefaultTask() {
         if (mappingFile != null) {
             val loggerMapping = loggerFactory.newOperation("AppCenter")
             loggerMapping.start("AppCenter Upload mapping file", "Step 0/4")
-            uploader.uploadSymbols(mappingFile, versionName, versionCode.toString()) {
+            uploader.uploadSymbols(mappingFile, "AndroidProguard", versionName, versionCode.toString()) {
                 loggerMapping.progress(it)
             }
             loggerMapping.completed("AppCenter Upload mapping completed", false)
@@ -51,7 +51,7 @@ open class UploadAppCenterTask : DefaultTask() {
             val loggerSymbol = loggerFactory.newOperation("AppCenter")
             loggerSymbol.start("AppCenter Upload symbol $it ", "Step 0/4")
             try {
-                uploader.uploadSymbols(toSymbolFile(it), versionName, versionCode.toString()) {
+                uploader.uploadSymbols(toSymbolFile(it), "Breakpad", versionName, versionCode.toString()) {
                     loggerSymbol.progress(it)
                 }
                 loggerSymbol.completed("AppCenter Upload symbol $it succeed", false)


### PR DESCRIPTION
Fixes #52

Adding `symbolType` as a parameter to `uploadSymbols` and have the correct value passed in for mappings.txt file and symbols zip files.