### PR TITLE
upgrade to OkHttp 4.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'kotlin'
 apply plugin: 'maven-publish'
 
 group 'com.betomorrow.gradle'
-version '1.2.1'
+version '1.2.2'
 
 repositories {
     mavenCentral()
@@ -36,8 +36,8 @@ dependencies {
     // Third Party
     compileOnly 'com.android.tools.build:gradle:3.6.0-rc01'
 
-    compile 'com.squareup.okhttp3:okhttp:3.12.1'
-    compile 'com.squareup.okhttp3:logging-interceptor:3.4.0'
+    compile 'com.squareup.okhttp3:okhttp:4.5.0'
+    compile 'com.squareup.okhttp3:logging-interceptor:4.5.0'
     compile 'com.squareup.retrofit2:converter-gson:2.6.1'
     compile 'com.squareup.retrofit2:retrofit:2.6.1'
 

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
@@ -1,6 +1,7 @@
 package com.betomorrow.gradle.appcenter.infra
 
 import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import java.io.File
 
 private const val RELEASE_URL_TEMPLATE = "https://appcenter.ms/orgs/%s/apps/%s/distribute/releases/%s"
@@ -32,8 +33,8 @@ class AppCenterUploader(
         val uploadResponse = doUploadApk(preparedUpload.uploadUrl, file, logger).execute()
         if (!uploadResponse.isSuccessful) {
             throw AppCenterUploaderException(
-                "Can't upload APK, code=${uploadResponse.code()}, " +
-                        "reason=${uploadResponse.body()?.string()}"
+                "Can't upload APK, code=${uploadResponse.code}, " +
+                        "reason=${uploadResponse.body?.string()}"
             )
         }
 
@@ -92,8 +93,8 @@ class AppCenterUploader(
         val uploadResponse = doUploadSymbol(preparedUpload.uploadUrl, mappingFile).execute()
         if (!uploadResponse.isSuccessful) {
             throw AppCenterUploaderException(
-                "Can't upload mapping, code=${uploadResponse.code()}, " +
-                        "reason=${uploadResponse.body()?.string()}"
+                "Can't upload mapping, code=${uploadResponse.code}, " +
+                        "reason=${uploadResponse.body?.string()}"
             )
         }
 
@@ -132,7 +133,7 @@ class AppCenterUploader(
         val request = Request.Builder()
             .url(uploadUrl)
             .addHeader("x-ms-blob-type", "BlockBlob")
-            .put(RequestBody.create(MediaType.parse("text/plain; charset=UTF-8"), file))
+            .put(RequestBody.create("text/plain; charset=UTF-8".toMediaTypeOrNull(), file))
             .build()
 
         return okHttpClient.newCall(request)


### PR DESCRIPTION
The issue I faced was in a conflicting OkHttp dependency between that apollo-gradle plugin and your plugin (see the attached image). Additionally, I noticed that there is a call to an internal OkHttp API (which I removed). I've bumped the patch version just so I could host this on my own binary repository without conflict.

Specifically, this was the issue:
```
Execution failed for task ':app:appCenterUploadMyAppVariant.
> okhttp3.internal.platform.Platform.log(ILjava/lang/String;Ljava/lang/Throwable;)V
```

Feel free to do what you like with this PR, as I can imagine reasons why you may not want to upgrade. In any case, I suggest making a release that allows for your consumers to use other plugins that have an OkHttp 4.+ dependency.

![Screen Shot 2020-08-19 at 4 22 58 PM](https://user-images.githubusercontent.com/4745799/90701051-3f87c900-e23c-11ea-8c9e-2c9596ace2c3.png)
 
