### PR TITLE
Fix: Allow getUpload to take longer than just 60 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:1.3.0"
+        classpath "gradle.plugin.com.betomorrow.gradle:appcenter-plugin:2.0.4"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'kotlin'
 apply plugin: 'maven-publish'
 
 group 'gradle.plugin.com.betomorrow.gradle'
-version '2.0.3'
+version '2.0.4'
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
+++ b/src/main/kotlin/com/betomorrow/gradle/appcenter/infra/AppCenterUploader.kt
@@ -10,8 +10,11 @@ private const val RELEASE_URL_TEMPLATE =
     "https://appcenter.ms/orgs/%s/apps/%s/distribute/releases/%s"
 private const val CONTENT_TYPE_APK = "application/vnd.android.package-archive"
 
-private const val RETRY_DELAY = 1_000L
-private const val MAX_RETRIES = 60
+// This leads to a maximum waiting time of about 15± minutes with a maximum total of 25 network requests (request time not included)
+// The longest time between 2 requests would be:
+private const val INITIAL_RETRY_DELAY = 1_000L
+private const val MAX_RETRIES = 25
+private const val BACKOFF_MULTIPLIER = 1.25
 
 class AppCenterUploader(
     private val apiFactory: AppCenterAPIFactory,
@@ -65,11 +68,16 @@ class AppCenterUploader(
 
         var requestCount = 0
         var uploadResult: GetUploadResponse?
+        var timeOutMs = INITIAL_RETRY_DELAY
         do {
             logger("Step 6/7 : Waiting for release to be ready to publish (${requestCount}s)")
             uploadResult = apiClient.getUpload(ownerName, appName, preparedUpload.id).executeOrThrow()
-            Thread.sleep(RETRY_DELAY)
+            Thread.sleep(timeOutMs)
+            timeOutMs = (timeOutMs * BACKOFF_MULTIPLIER).toLong()
 
+            if(uploadResult.uploadStatus == "error") {
+                throw AppCenterUploaderException("Fetching release id failed, upload status equals 'error'.")
+            }
             if (++requestCount >= MAX_RETRIES) {
                 throw AppCenterUploaderException("Fetching release id failed: Tried $requestCount times.")
             }


### PR DESCRIPTION
This potentially fixes: #81.

It seems AppCenter nowadays takes longer to process releases. This plugin currently just waits for 60 seconds, and during this time it makes 60 attempts. However the official AppCenter CLI waits forever, and uses a 2 second timeout: https://github.com/microsoft/appcenter-cli/blob/9974d6d925c040a7ca2cc3a814ba292d9fbcab73/src/commands/distribute/release.ts#L443

Obviously I don't think this plugin should wait forever, instead I made it so that it waits for about 15 minutes in total instead of 60 seconds it is currently waiting. I also added an increasing timeout between attempts, to avoid having too many API calls. If we would put this on a graph it would look like this:

<img width="595" alt="image" src="https://user-images.githubusercontent.com/6614322/152518509-7a1a5610-7649-49ce-8cc1-96675f154aac.png">

So worst case scenario (when it reaches attempt 25) it waits for about 3 minutes before trying again. I believe that should be reasonable.

I also noticed the official AppCenter CLI stops attempting if the back-end returns "error", so I also implemented that.

I hope we can quickly get this as a hot-fix, let me know what you think. Maybe it would be wise to make these values configurable in the future?
